### PR TITLE
fix modal/cli-command bug

### DIFF
--- a/src/components/Modal/src/index.vue
+++ b/src/components/Modal/src/index.vue
@@ -1,6 +1,6 @@
 <template>
   <teleport to="body">
-    <div class="flex flex-col items-center justify-center z-$modal-z-index absolute top-0 left-0 bottom-0 right-0 bg-[rgba(0,0,0,.5)]" v-if="visible">
+    <div class="grid items-center justify-center z-$modal-z-index overflow-auto absolute top-0 left-0 bottom-0 right-0 bg-[rgba(0,0,0,.5)]" v-if="visible">
       <div class="min-w-1/3 bg-white">
         <div class="flex justify-between items-center pt-20px pb-10px px-20px">
           <div class="text-18px">

--- a/src/views/components/CliCommand.vue
+++ b/src/views/components/CliCommand.vue
@@ -35,11 +35,11 @@
             <span class="text-purple-700">autok3s</span>&nbsp;<span class="cli-command__sub-cmd">create</span>
             <template v-for="(o, index) in cmdOptions" :key="index">
               <span class="text-blue-700">&nbsp;{{o.option}}</span>
-              <span class="cli-command__value" :class="optionValueClass(o.value)" v-if="o.value">&nbsp;{{o.value}}</span>
+              <span class="cli-command__value break-all" :class="optionValueClass(o.value)" v-if="o.value">&nbsp;{{o.value}}</span>
             </template>
             <template v-if="registryContent">
               <span class="text-blue-700">&nbsp;--registry </span>
-              <span class="cli-command__value text-red-500">{{registryPlaceholder}}</span>
+              <span class="cli-command__value break-all text-red-500">{{registryPlaceholder}}</span>
             </template>
           </code>
           <!-- <code>{{createCmd}} <span class="text-red-500" v-if="registryContent">--registry {{registryPlaceholder}}</span></code> -->


### PR DESCRIPTION
1. fix(modal): fix modal content being hidden if there is too much content
2. fix(cli-command): set word break all for command value