### PR TITLE
fix(cluster-actions): hide upgrade action for k3d

### DIFF
--- a/src/views/cluster-explorer/core/clusters/components/ClusterActions.vue
+++ b/src/views/cluster-explorer/core/clusters/components/ClusterActions.vue
@@ -84,7 +84,7 @@ export default {
           command: 'downloadKubeConfig'
         })
 
-        if (props.cluster.actions.upgrade) {
+        if (props.cluster.actions.upgrade && props.cluster.provider !== 'k3d') {
           actions.splice(1, 0, {
             label: 'Upgrade',
             icon: 'terminal',

--- a/src/views/cluster-explorer/core/clusters/components/UpgradeModal.vue
+++ b/src/views/cluster-explorer/core/clusters/components/UpgradeModal.vue
@@ -130,7 +130,7 @@ watch(
             :desc="provider?.config?.['k3s-version']?.description"
           />
         </div>
-        <KAlert v-if="saveError" type="error" :title="saveError"></KAlert>
+        <KAlert v-if="saveError" type="error" :title="stringify(saveError)"></KAlert>
       </KLoading>
     </template>
     <template #footer>


### PR DESCRIPTION
fix(cluster-actions): hide upgrade action for k3d
fix(upgrade-modal): show response error message if save failed